### PR TITLE
removing unused documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,6 @@ On Windows environment you may run the `mvnw.cmd` command.
 mvnw.cmd clean install
 ```
 
-In order to test the REST API, you can use the "/swagger-ui.html" or the [POSTMAN collection](accessible-biotechnology.postman_collection.json)
-
-
 ### Installation
 
 By running `clean install` gaol, maven will install the artifact to the .m2 folder


### PR DESCRIPTION
Since this project won't have REST APIs, swagger related documentation removed.